### PR TITLE
Make CI run checkout PR for backlogger_preview

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -9,18 +9,17 @@ on:
       - reopened
       - synchronize
       - closed
+    branches:
+      - "**"
 jobs:
   backlogger_preview:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Run the action implemented in this repo
         uses: ./
         with:
           config: queries.yaml
-          ref: ${{ github.event.pull_request.head.sha }}
       - uses: rossjrw/pr-preview-action@v1
         with:
           source-dir: gh-pages

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -20,6 +20,7 @@ jobs:
         uses: ./
         with:
           config: queries.yaml
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: rossjrw/pr-preview-action@v1
         with:
           source-dir: gh-pages

--- a/action.yaml
+++ b/action.yaml
@@ -33,6 +33,7 @@ runs:
       with:
         repository: openSUSE/backlogger
         path: backlogger
+        ref: ${{ github.event.pull_request.head.sha }}
     - uses: actions/setup-python@v5
       with:
         python-version: 3.12


### PR DESCRIPTION
Switch trigger to pull_request_target and adjust the checkout actions to run against the latest code in the PR.
Although it works for backlogger, it might impact when the workflow run in another repository.

https://progress.opensuse.org/issues/158236